### PR TITLE
Add admin config blueprint

### DIFF
--- a/admin_blueprint.py
+++ b/admin_blueprint.py
@@ -1,0 +1,68 @@
+from flask import Blueprint, render_template, request, redirect, url_for, Response
+from functools import wraps
+import os
+import json
+import requests
+from functions.config_loader import get_config
+
+admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
+
+USERNAME = os.environ.get('ADMIN_USERNAME', 'admin')
+PASSWORD = os.environ.get('ADMIN_PASSWORD', 'password')
+
+
+def check_auth(username: str, password: str) -> bool:
+    return username == USERNAME and password == PASSWORD
+
+
+def authenticate() -> Response:
+    return Response(
+        'Authentication required', 401,
+        {'WWW-Authenticate': 'Basic realm="Login Required"'}
+    )
+
+
+def requires_auth(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.authorization
+        if not auth or not check_auth(auth.username, auth.password):
+            return authenticate()
+        return f(*args, **kwargs)
+    return decorated
+
+
+@admin_bp.route('/config', methods=['GET', 'POST'])
+@requires_auth
+def config_page():
+    if request.method == 'POST':
+        # Determine config data
+        if request.is_json:
+            config_data = request.get_json(silent=True) or {}
+        else:
+            config_text = request.form.get('config', '{}')
+            try:
+                config_data = json.loads(config_text)
+            except json.JSONDecodeError:
+                return Response('Invalid JSON', status=400)
+        # Write config.json
+        with open('config.json', 'w') as f:
+            json.dump(config_data, f, indent=2)
+        # Notify app to reload config
+        port = 5000
+        try:
+            port = int(get_config().get('PORT', 5000))
+        except Exception:
+            pass
+        try:
+            requests.post(f'http://localhost:{port}/api/notify_config_reload')
+        except Exception:
+            pass
+        return redirect(url_for('admin.config_page'))
+
+    # GET request
+    try:
+        config_json = json.dumps(get_config(), indent=2)
+    except Exception:
+        config_json = '{}'
+    return render_template('admin_config.html', config=config_json)

--- a/dream_recorder.py
+++ b/dream_recorder.py
@@ -15,6 +15,7 @@ from flask_socketio import SocketIO, emit
 from functions.dream_db import DreamDB
 from functions.audio import create_wav_file, process_audio
 from functions.config_loader import load_config, get_config
+from admin_blueprint import admin_bp
 
 # Configure logging
 logging.basicConfig(level=getattr(logging, get_config()["LOG_LEVEL"]))
@@ -63,6 +64,9 @@ socketio = SocketIO(app, cors_allowed_origins="*", async_mode='gevent')
 
 # Initialize DreamDB
 dream_db = DreamDB()
+
+# Register blueprints
+app.register_blueprint(admin_bp)
 
 # =============================
 # Core Logic / Helper Functions

--- a/templates/admin_config.html
+++ b/templates/admin_config.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Configuration</title>
+</head>
+<body>
+    <h1>Configuration</h1>
+    <form method="post">
+        <textarea name="config" rows="20" cols="80">{{ config }}</textarea><br>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,30 @@
+import json
+from base64 import b64encode
+
+
+def auth_headers(username='admin', password='password'):
+    token = b64encode(f"{username}:{password}".encode()).decode()
+    return {'Authorization': f'Basic {token}'}
+
+
+def test_admin_config_requires_auth(test_client):
+    resp = test_client.get('/admin/config')
+    assert resp.status_code == 401
+
+
+def test_admin_config_get_success(test_client, mocker):
+    mocker.patch('functions.config_loader.get_config', return_value={'PORT': 5000, 'FOO': 'bar'})
+    resp = test_client.get('/admin/config', headers=auth_headers())
+    assert resp.status_code == 200
+    assert b'FOO' in resp.data
+
+
+def test_admin_config_post_updates(test_client, mocker):
+    mocker.patch('functions.config_loader.get_config', return_value={'PORT': 5000})
+    mopen = mocker.mock_open()
+    mocker.patch('builtins.open', mopen)
+    post_mock = mocker.patch('requests.post')
+    resp = test_client.post('/admin/config', json={'A': 1}, headers=auth_headers())
+    assert resp.status_code in (302, 200)
+    mopen.assert_called_with('config.json', 'w')
+    post_mock.assert_called_with('http://localhost:5000/api/notify_config_reload')


### PR DESCRIPTION
## Summary
- create admin blueprint with basic authentication
- expose `/admin/config` route for viewing and updating configuration
- register blueprint in app and add minimal template
- test blueprint behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gevent')*

------
https://chatgpt.com/codex/tasks/task_e_6869132c7b88832193736e87262909a6