### PR TITLE
Add mobile socket and media recording

### DIFF
--- a/DreamRecorderMobile/package.json
+++ b/DreamRecorderMobile/package.json
@@ -15,7 +15,10 @@
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
     "react-native-safe-area-context": "^4.10.1",
-    "react-native-screens": "^3.31.1"
+    "react-native-screens": "^3.31.1",
+    "socket.io-client": "^4.7.2",
+    "expo-av": "^13.0.4",
+    "react-native-video": "^6.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/DreamRecorderMobile/src/screens/PlaybackScreen.tsx
+++ b/DreamRecorderMobile/src/screens/PlaybackScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Button } from 'react-native';
+import Video from 'react-native-video';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/AppNavigator'; // We'll create this next
 
@@ -8,16 +9,12 @@ type PlaybackScreenProps = NativeStackScreenProps<RootStackParamList, 'Playback'
 const PlaybackScreen: React.FC<PlaybackScreenProps> = ({ route, navigation }) => {
   const { dreamId } = route.params;
 
-  // In a real app, use dreamId to fetch video URL and details
-  // and use a <Video> component to play it.
+  const videoUrl = `http://localhost:8000/videos/${dreamId}.mp4`;
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Playing Dream</Text>
-      <View style={styles.videoPlaceholder}>
-        <Text>Video Player for Dream ID: {dreamId}</Text>
-        {/* Placeholder for <Video /> component */}
-      </View>
+      <Video source={{ uri: videoUrl }} style={styles.video} controls resizeMode="contain" />
       <View style={styles.controls}>
         <Button
           title="Play Previous (Simulated)"
@@ -44,14 +41,11 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 20,
   },
-  videoPlaceholder: {
+  video: {
     width: '100%',
     aspectRatio: 16 / 9, // Common video aspect ratio
-    backgroundColor: '#333', // Dark placeholder for video
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: '#000',
     marginBottom: 20,
-    borderRadius: 8,
   },
   controls: {
     flexDirection: 'row',

--- a/DreamRecorderMobile/src/screens/ProcessingScreen.tsx
+++ b/DreamRecorderMobile/src/screens/ProcessingScreen.tsx
@@ -1,28 +1,42 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { RootStackParamList } from '../navigation/AppNavigator'; // We'll create this next
+import { RootStackParamList } from '../navigation/AppNavigator';
+import api from '../services/api';
 
 type ProcessingScreenProps = NativeStackScreenProps<RootStackParamList, 'Processing'>;
 
 const ProcessingScreen: React.FC<ProcessingScreenProps> = ({ navigation }) => {
-  // Simulate processing and then navigate to Playback
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      // In a real app, this navigation would be triggered by a SocketIO event
-      // indicating processing is complete and video is ready.
-      navigation.replace('Playback', { dreamId: 'generatedDreamId456' }); // Pass a dummy ID
-    }, 3000); // Simulate 3 seconds of processing
+  const [status, setStatus] = useState('Transcribing audio...');
 
-    return () => clearTimeout(timer); // Cleanup timer
+  useEffect(() => {
+    api.connect();
+
+    const handleState = (msg: string) => setStatus(msg);
+    const handleTrans = (msg: string) => setStatus(msg);
+    const handlePrompt = (msg: string) => setStatus(msg);
+    const handleReady = (id: string) => {
+      navigation.replace('Playback', { dreamId: id });
+    };
+
+    api.on('state_update', handleState);
+    api.on('transcription_update', handleTrans);
+    api.on('video_prompt_update', handlePrompt);
+    api.on('video_ready', handleReady);
+
+    return () => {
+      api.off('state_update', handleState);
+      api.off('transcription_update', handleTrans);
+      api.off('video_prompt_update', handlePrompt);
+      api.off('video_ready', handleReady);
+    };
   }, [navigation]);
 
   return (
     <View style={styles.container}>
       <ActivityIndicator size="large" color="#0000ff" />
       <Text style={styles.title}>Processing your dream...</Text>
-      <Text style={styles.statusText}>Transcribing audio...</Text>
-      {/* Later, this text could be updated dynamically based on SocketIO events */}
+      <Text style={styles.statusText}>{status}</Text>
     </View>
   );
 };

--- a/DreamRecorderMobile/src/screens/RecordingScreen.tsx
+++ b/DreamRecorderMobile/src/screens/RecordingScreen.tsx
@@ -1,25 +1,59 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, Button } from 'react-native';
+import { Audio } from 'expo-av';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/AppNavigator'; // We'll create this next
+import api from '../services/api';
 
 type RecordingScreenProps = NativeStackScreenProps<RootStackParamList, 'Recording'>;
 
 const RecordingScreen: React.FC<RecordingScreenProps> = ({ navigation }) => {
-  // In a real app, this would connect to audio recording logic
-  // and show recording animations/status.
+  const [recording, setRecording] = useState<Audio.Recording | null>(null);
+
+  const startRecording = async () => {
+    try {
+      await Audio.requestPermissionsAsync();
+      await Audio.setAudioModeAsync({
+        allowsRecordingIOS: true,
+        playsInSilentModeIOS: true,
+      });
+      const { recording } = await Audio.Recording.createAsync(
+        Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY
+      );
+      api.connect();
+      setRecording(recording);
+    } catch (err) {
+      console.warn('Failed to start recording', err);
+    }
+  };
+
+  const stopRecording = async () => {
+    if (!recording) return;
+    try {
+      await recording.stopAndUnloadAsync();
+      const uri = recording.getURI();
+      if (uri) {
+        api.sendAudioChunk({ uri });
+      }
+    } catch (err) {
+      console.warn('Failed to stop recording', err);
+    } finally {
+      setRecording(null);
+      navigation.replace('Processing');
+    }
+  };
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Recording Dream...</Text>
-      {/* Placeholder for recording animation or VU meter */}
       <View style={styles.vuMeterPlaceholder}>
         <Text>Recording Animation Here</Text>
       </View>
-      <Button
-        title="Stop Recording (Simulated)"
-        onPress={() => navigation.replace('Processing')} // Use replace to prevent going back to Recording
-      />
+      {recording ? (
+        <Button title="Stop Recording" onPress={stopRecording} />
+      ) : (
+        <Button title="Start Recording" onPress={startRecording} />
+      )}
     </View>
   );
 };

--- a/DreamRecorderMobile/src/services/api.ts
+++ b/DreamRecorderMobile/src/services/api.ts
@@ -1,0 +1,31 @@
+import { io, Socket } from 'socket.io-client';
+
+class ApiService {
+  private socket: Socket | null = null;
+
+  connect() {
+    if (!this.socket) {
+      // TODO: replace URL with your backend endpoint
+      this.socket = io('http://localhost:8000');
+    }
+  }
+
+  disconnect() {
+    this.socket?.disconnect();
+    this.socket = null;
+  }
+
+  sendAudioChunk(data: any) {
+    this.socket?.emit('audio_chunk', data);
+  }
+
+  on(event: string, callback: (...args: any[]) => void) {
+    this.socket?.on(event, callback);
+  }
+
+  off(event: string, callback?: (...args: any[]) => void) {
+    this.socket?.off(event, callback);
+  }
+}
+
+export default new ApiService();


### PR DESCRIPTION
## Summary
- add socket.io-client, expo-av and react-native-video dependencies
- add basic socket API service
- record audio and stream URI via socket
- handle socket events on Processing screen
- play returned video in Playback screen

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869132aa95c8321b4f457b0a682a074