### PR TITLE
Introduce per-client playback sessions

### DIFF
--- a/dream_recorder.py
+++ b/dream_recorder.py
@@ -12,6 +12,7 @@ import argparse
 
 from flask import Flask, render_template, jsonify, request, send_file
 from flask_socketio import SocketIO, emit
+from dataclasses import dataclass
 from functions.dream_db import DreamDB
 from functions.audio import create_wav_file, process_audio
 from functions.config_loader import load_config, get_config
@@ -33,11 +34,15 @@ recording_state = {
     'video_url': None
 }
 
-# Video playback state
-video_playback_state = {
-    'current_index': 0,  # Index of the current video being played
-    'is_playing': False  # Whether a video is currently playing
-}
+
+# Video playback session management
+@dataclass
+class PlaybackSession:
+    current_index: int = 0  # Index of the current video being played
+    is_playing: bool = False  # Whether a video is currently playing
+
+# Active playback sessions keyed by Socket.IO session id (SID)
+playback_sessions = {}
 
 # Audio buffer for storing chunks
 audio_buffer = io.BytesIO()
@@ -105,6 +110,8 @@ def init_sample_dreams_if_missing():
 @socketio.on('connect')
 def handle_connect(auth=None):
     """Handle new client connection."""
+    sid = request.sid
+    playback_sessions[sid] = PlaybackSession()
     if logger:
         logger.info('Client connected')
     emit('state_update', recording_state)
@@ -112,6 +119,8 @@ def handle_connect(auth=None):
 @socketio.on('disconnect')
 def handle_disconnect():
     """Handle client disconnection."""
+    sid = request.sid
+    playback_sessions.pop(sid, None)
     if logger:
         logger.info('Client disconnected')
 
@@ -176,24 +185,30 @@ def handle_show_previous_dream():
             if logger:
                 logger.warning("No dreams found to cycle through.")
             return None
+        # Retrieve or create this client's playback session
+        sid = request.sid
+        session = playback_sessions.setdefault(sid, PlaybackSession())
+
         # If we're currently playing a video, show the next one in sequence
-        if video_playback_state['is_playing']:
-            video_playback_state['current_index'] += 1
-            if video_playback_state['current_index'] >= len(dreams):
-                video_playback_state['current_index'] = 0  # Wrap around
+        if session.is_playing:
+            session.current_index += 1
+            if session.current_index >= len(dreams):
+                session.current_index = 0  # Wrap around
         else:
             # If not playing, start with the most recent dream
-            video_playback_state['current_index'] = 0
-            video_playback_state['is_playing'] = True
+            session.current_index = 0
+            session.is_playing = True
+
         # Get the dream at the current index
-        dream = dreams[video_playback_state['current_index']]
+        dream = dreams[session.current_index]
+
         # Emit the video URL to the client
         socketio.emit('play_video', {
             'video_url': f"/media/video/{dream['video_filename']}",
             'loop': True  # Enable looping for the video
         })
         if logger:
-            logger.info(f"Emitted play_video for dream index {video_playback_state['current_index']}: {dream['video_filename']}")
+            logger.info(f"Emitted play_video for dream index {session.current_index}: {dream['video_filename']}")
 
         if not dream:
             socketio.emit('error', {'message': 'No dreams found'})

--- a/tests/test_dream_recorder.py
+++ b/tests/test_dream_recorder.py
@@ -110,9 +110,10 @@ def test_handle_show_previous_dream_no_dream(monkeypatch, mocker):
         def info(self, msg): pass
         def error(self, msg): pass
     monkeypatch.setattr(dream_recorder, 'logger', FakeLogger())
-    # Set video_playback_state to simulate playing
-    dream_recorder.video_playback_state['is_playing'] = True
-    dream_recorder.video_playback_state['current_index'] = 0
+    dream_recorder.playback_sessions.clear()
+    sid = 'test-sid'
+    dream_recorder.playback_sessions[sid] = dream_recorder.PlaybackSession(current_index=0, is_playing=True)
+    monkeypatch.setattr(dream_recorder, 'request', type('Req', (), {'sid': sid}))
     dream_recorder.handle_show_previous_dream()
     assert any('No dreams found to cycle through.' in msg for msg in logs)
 
@@ -130,9 +131,10 @@ def test_handle_show_previous_dream_dream_is_none(monkeypatch, mocker):
     # Patch socketio.emit to record calls
     emitted = []
     monkeypatch.setattr(dream_recorder.socketio, 'emit', lambda name, data=None: emitted.append((name, data)))
-    # Set video_playback_state to simulate playing
-    dream_recorder.video_playback_state['is_playing'] = True
-    dream_recorder.video_playback_state['current_index'] = 0
+    dream_recorder.playback_sessions.clear()
+    sid = 'test-sid'
+    dream_recorder.playback_sessions[sid] = dream_recorder.PlaybackSession(current_index=0, is_playing=True)
+    monkeypatch.setattr(dream_recorder, 'request', type('Req', (), {'sid': sid}))
     dream_recorder.handle_show_previous_dream()
     # Should emit error
     assert any(name == 'error' for name, _ in emitted)

--- a/tests/test_socketio.py
+++ b/tests/test_socketio.py
@@ -24,10 +24,8 @@ def test_start_and_stop_recording(socketio_client, mocker):
 
 def test_playback_flow(mocker):
     # Patch dream_db before creating the client
-    from dream_recorder import socketio, app, video_playback_state
-    # Reset playback state
-    video_playback_state['current_index'] = 0
-    video_playback_state['is_playing'] = False
+    from dream_recorder import socketio, app, playback_sessions, PlaybackSession
+    playback_sessions.clear()
     mock_db = mocker.MagicMock()
     mock_db.get_all_dreams.return_value = [
         {'video_filename': 'dream1.mp4'},
@@ -35,6 +33,7 @@ def test_playback_flow(mocker):
     ]
     mocker.patch('dream_recorder.dream_db', mock_db)
     client = socketio.test_client(app)
+    sid = client.sid
     # Play latest dream
     client.emit('show_previous_dream')
     time.sleep(0.1)
@@ -46,6 +45,7 @@ def test_playback_flow(mocker):
     received = client.get_received()
     assert any(x['name'] == 'play_video' and 'dream2.mp4' in x['args'][0]['video_url'] for x in received)
     client.disconnect()
+    assert sid not in playback_sessions
 
 def test_no_dreams_playback(socketio_client, mock_dream_db):
     mock_dream_db.get_all_dreams.return_value = []


### PR DESCRIPTION
## Summary
- add `PlaybackSession` dataclass and manage playback sessions by SID
- associate/dispose sessions on connect/disconnect
- make `handle_show_previous_dream` use the client's session
- update tests for new session handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dream_recorder')*

------
https://chatgpt.com/codex/tasks/task_e_686913280b948321bf15169b35b3a464